### PR TITLE
refactor: --experimental-fetch flag & better npm scripts naming

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 18
 
       - name: Scrape data
-        run: yarn scrape
+        run: yarn script:scrape
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky install",
-    "scrape": "node --experimental-fetch scripts/scrape.mjs"
+    "script:scrape": "node --experimental-fetch scripts/scrape.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^4.5.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky install",
-    "scrape": "node scripts/scrape.mjs"
+    "scrape": "node --experimental-fetch scripts/scrape.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^4.5.4",

--- a/scripts/scrape.mjs
+++ b/scripts/scrape.mjs
@@ -1,5 +1,3 @@
-// Run this with --experimental-fetch
-
 import fs from 'fs/promises'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'


### PR DESCRIPTION
In order to run the scripts/scrape.mjs, it is mandatory to use the flag --experimental-fetch, thus running `<package-manager> run scrape` will prompt an error. With this patch, other developers could easily run the script without inspecting the script first to make it work.

better naming: merge `build` with `postbuild`, merging both could resolve into -> `build` and `build:post`. The same applies with scripts/ folder, from `scrape` into `script:scrape`.

thus will resolve into:
```json
"build": "next build",
"build:post": "next-sitemap",
"script:scrape": "node --expe...",
```

https://stackoverflow.com/questions/47606101/what-is-colon-in-npm-script-names
https://corgibytes.com/blog/2017/04/18/npm-tips/