### PR TITLE
Add "www" to NodeMCU website

### DIFF
--- a/src/_data/websites.ts
+++ b/src/_data/websites.ts
@@ -178,7 +178,7 @@ export const devStarterPack = [
   // Microcontroller
   { website: 'arduino.cc', icon: siArduino },
   { website: 'adafruit.com', icon: siAdafruit },
-  { website: 'nodemcu.com', icon: nodeMCUIcon },
+  { website: 'www.nodemcu.com', icon: nodeMCUIcon },
   { website: 'st.com', icon: siStmicroelectronics },
   // SocMed
   { website: 'slack.com', icon: siSlack },


### PR DESCRIPTION
I noticed when I tried to resolve the domain from my company's network (not blocked ofc), it didn't return IP Addresses. Then I add "www" and it works!