### PR TITLE
use `endOfLine` in prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,7 @@
   "singleQuote": true,
   "trailingComma": "none",
   "semi": false,
+  "endOfLine": "auto",
   "proseWrap": "always",
   "printWidth": 100,
   "jsxSingleQuote": true


### PR DESCRIPTION
Please spare a thought for this poor Windows user. 😢

![image](https://user-images.githubusercontent.com/5663877/182199548-204645bc-9677-4220-942b-0717272348c5.png)
