### PR TITLE
Fix refresh data workflow

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Scrape data
         run: yarn script:scrape
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
saya melihat workflow akhir-akhir ini gagal semua. 

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/20186786/230701244-8aa86187-4ac6-4a9c-8890-517445422c0d.png">


PR ini menambahkan fixing simple yaitu dengan menonaktifkan pengecekan insecure tls, thanks to https://stackoverflow.com/a/48960988.

Setelah ini harusnya workflow akan jalan, ini hasil trigger manual di repo forkinganku: https://github.com/lakuapik/kominfo-d-/actions/runs/4643147979

